### PR TITLE
use strconv.ParseUint to parse networkID to fix arm compile overflow …

### DIFF
--- a/types/cfxaddress/network_type.go
+++ b/types/cfxaddress/network_type.go
@@ -79,11 +79,11 @@ func getIDWhenBeginWithNet(netIDStr string) (uint32, error) {
 		return 0, errors.Errorf("Invalid network: %v", netIDStr)
 	}
 
-	netID, err := strconv.Atoi(string(netIDStr[3:]))
+	netID, err := strconv.ParseUint(string(netIDStr[3:]), 0, 32)
 	if err != nil {
 		return 0, err
 	}
-	if netID >= (1 << 32) {
+	if netID > (1<<32 - 1) {
 		return 0, errors.Errorf("NetworkID %v not in range 0~0xffffffff", netID)
 	}
 	return uint32(netID), nil

--- a/types/cfxaddress/network_type.go
+++ b/types/cfxaddress/network_type.go
@@ -83,8 +83,5 @@ func getIDWhenBeginWithNet(netIDStr string) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	if netID > (1<<32 - 1) {
-		return 0, errors.Errorf("NetworkID %v not in range 0~0xffffffff", netID)
-	}
 	return uint32(netID), nil
 }


### PR DESCRIPTION
…error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/go-conflux-sdk/58)
<!-- Reviewable:end -->
