### PR TITLE
Set http request header 'Connection' to 'Keep-Alive' to reuse tcp connection

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -125,7 +125,8 @@ func DialHTTPWithClient(endpoint string, client *fasthttp.Client) (*Client, erro
 		req.Header.SetMethod("POST")
 		req.Header.Set("Content-Type", contentType)
 		req.Header.Set("Accept", contentType)
-		req.Header.Set("Connection", "close")
+		// req.Header.Set("Connection", "close")
+		req.Header.Set("Connection", "Keep-Alive")
 		return &httpConn{client: client, req: &req, closeCh: make(chan interface{})}, nil
 	})
 }


### PR DESCRIPTION
Set http request header 'Connection' to 'Keep-Alive' to reuse tcp connection for avoiding large TIME_WAIT on full-node, full-node need set 'jsonrpc_http_keep_alive=true', otherwise it will still set 'Connection' to 'Close' in http response of full-node

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/go-conflux-sdk/76)
<!-- Reviewable:end -->
