### PR TITLE
Add remote client addr to websocket context for possible use

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -111,6 +111,7 @@ type clientConn struct {
 
 func (c *Client) newClientConn(conn ServerCodec) *clientConn {
 	ctx := context.WithValue(context.Background(), clientContextKey{}, c)
+	ctx = context.WithValue(ctx, "remote", conn.remoteAddr())
 	handler := newHandler(ctx, conn, c.idgen, c.services)
 	return &clientConn{conn, handler}
 }

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 const (
@@ -184,9 +186,13 @@ func NewFuncCodec(conn deadlineCloser, encode, decode func(v interface{}) error)
 		decode:  decode,
 		conn:    conn,
 	}
+
 	if ra, ok := conn.(ConnRemoteAddr); ok {
 		codec.remote = ra.RemoteAddr()
+	} else if c, ok := conn.(*websocket.Conn); ok { // extract remote address from websocket connection
+		codec.remote = c.RemoteAddr().String()
 	}
+
 	return codec
 }
 


### PR DESCRIPTION
Infura needs remote client address to distribute fullnode with consistent hash algorithm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/go-conflux-sdk/91)
<!-- Reviewable:end -->
