### PR TITLE
Add rpc client pointer to context for possible use

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -111,7 +111,10 @@ type clientConn struct {
 
 func (c *Client) newClientConn(conn ServerCodec) *clientConn {
 	ctx := context.WithValue(context.Background(), clientContextKey{}, c)
+	// add websocket remote address to the context
 	ctx = context.WithValue(ctx, "remote", conn.remoteAddr())
+	// add rpc client to the context
+	ctx = context.WithValue(ctx, "client", c)
 	handler := newHandler(ctx, conn, c.idgen, c.services)
 	return &clientConn{conn, handler}
 }


### PR DESCRIPTION
Infura needs get rpc client from context to close the websocket connection when any error occurs during delegation to fullnode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/go-conflux-sdk/92)
<!-- Reviewable:end -->
