### PR TITLE
Add variadic arguments support for rpc service

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -323,7 +323,7 @@ func (h *handler) handleCall(cp *callProc, msg *jsonrpcMessage) *jsonrpcMessage 
 	if callb == nil {
 		return msg.errorResponse(&methodNotFoundError{method: msg.Method})
 	}
-	args, err := parsePositionalArguments(msg.Params, callb.argTypes)
+	args, err := parsePositionalArguments(msg.Params, callb.argTypes, callb.isVariadic)
 	if err != nil {
 		return msg.errorResponse(&invalidParamsError{err.Error()})
 	}
@@ -364,7 +364,7 @@ func (h *handler) handleSubscribe(cp *callProc, msg *jsonrpcMessage) *jsonrpcMes
 
 	// Parse subscription name arg too, but remove it before calling the callback.
 	argTypes := append([]reflect.Type{stringType}, callb.argTypes...)
-	args, err := parsePositionalArguments(msg.Params, argTypes)
+	args, err := parsePositionalArguments(msg.Params, argTypes, callb.isVariadic)
 	if err != nil {
 		return msg.errorResponse(&invalidParamsError{err.Error()})
 	}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -192,7 +192,7 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.Reader, 
 	}
 	// fmt.Printf("do request done req:%+v\n respbody:%#v\n\n", req, resp.Body)
 	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
-		return bytes.NewReader(resp.Body()), errors.New(string(resp.StatusCode()))
+		return bytes.NewReader(resp.Body()), fmt.Errorf("%v", resp.StatusCode())
 	}
 	return bytes.NewReader(resp.Body()), nil
 }

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -326,10 +326,11 @@ func parseArgumentArray(dec *json.Decoder, types []reflect.Type, isVariadic bool
 			return args, fmt.Errorf("too many arguments, want at most %d", len(types))
 		}
 
-		argval := reflect.New(types[i])
-		// For variadic parameters, final argument type is slice but they are passed one by one as an element type.
-		if isVariadic && i >= len(types)-1 {
+		var argval reflect.Value
+		if isVariadic && i >= len(types)-1 { // final argument type is slice, but variadic parameters are passed one by one as an element item type.
 			argval = reflect.New(types[len(types)-1].Elem())
+		} else {
+			argval = reflect.New(types[i])
 		}
 
 		if err := dec.Decode(argval.Interface()); err != nil {

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -53,6 +53,7 @@ type callback struct {
 	fn          reflect.Value  // the function
 	rcvr        reflect.Value  // receiver object of method, set if fn is method
 	argTypes    []reflect.Type // input argument types
+	isVariadic  bool           // true if the function type's final input parameter is a "..." parameter
 	hasCtx      bool           // method's first argument is a context (not included in argTypes)
 	errPos      int            // err return idx, of -1 when method cannot return error
 	isSubscribe bool           // true if this is a subscription callback
@@ -135,7 +136,7 @@ func suitableCallbacks(receiver reflect.Value) map[string]*callback {
 // is unsuitable as an RPC callback.
 func newCallback(receiver, fn reflect.Value) *callback {
 	fntype := fn.Type()
-	c := &callback{fn: fn, rcvr: receiver, errPos: -1, isSubscribe: isPubSub(fntype)}
+	c := &callback{fn: fn, rcvr: receiver, errPos: -1, isSubscribe: isPubSub(fntype), isVariadic: fntype.IsVariadic()}
 	// Determine parameter types. They must all be exported or builtin types.
 	c.makeArgTypes()
 

--- a/rpc/testdata/reqresp-paramsvariadic.js
+++ b/rpc/testdata/reqresp-paramsvariadic.js
@@ -1,0 +1,10 @@
+// This test checks that calls with variadic param(s) work.
+
+--> {"jsonrpc": "2.0", "id": 2, "method": "test_variadicArgs", "params": ["x", 3]}
+<-- {"jsonrpc":"2.0","id":2,"result":[{"String":"x","Int":3,"Args":null}]}
+
+--> {"jsonrpc": "2.0", "id": 2, "method": "test_variadicArgs", "params": ["x", 3, {"S": "foo"}]}
+<-- {"jsonrpc":"2.0","id":2,"result":[{"String":"x","Int":3,"Args":{"S":"foo"}}]}
+
+--> {"jsonrpc": "2.0", "id": 2, "method": "test_variadicArgs", "params": ["x", 3, {"S": "foo"}, {"S": "bar"}]}
+<-- {"jsonrpc":"2.0","id":2,"result":[{"String":"x","Int":3,"Args":{"S":"foo"}},{"String":"x","Int":3,"Args":{"S":"bar"}}]}

--- a/rpc/testdata/subscription.js
+++ b/rpc/testdata/subscription.js
@@ -8,5 +8,20 @@
 <-- {"jsonrpc":"2.0","method":"nftest_subscription","params":{"subscription":"0x1","result":4}}
 <-- {"jsonrpc":"2.0","method":"nftest_subscription","params":{"subscription":"0x1","result":5}}
 
+--> {"jsonrpc":"2.0","id":1,"method":"nftest_subscribe","params":["echoVariadicArgs"]}
+<-- {"jsonrpc":"2.0","id":1,"result":"0x2"}
+<-- {"jsonrpc":"2.0","method":"nftest_subscription","params":{"subscription":"0x2","result":"hi world"}}
+
+--> {"jsonrpc":"2.0","id":1,"method":"nftest_subscribe","params":["echoVariadicArgs", "david"]}
+<-- {"jsonrpc":"2.0","id":1,"result":"0x3"}
+<-- {"jsonrpc":"2.0","method":"nftest_subscription","params":{"subscription":"0x3","result":"hi world"}}
+<-- {"jsonrpc":"2.0","method":"nftest_subscription","params":{"subscription":"0x3","result":"hi david"}}
+
+--> {"jsonrpc":"2.0","id":1,"method":"nftest_subscribe","params":["echoVariadicArgs", "jimmy", "lily"]}
+<-- {"jsonrpc":"2.0","id":1,"result":"0x4"}
+<-- {"jsonrpc":"2.0","method":"nftest_subscription","params":{"subscription":"0x4","result":"hi world"}}
+<-- {"jsonrpc":"2.0","method":"nftest_subscription","params":{"subscription":"0x4","result":"hi jimmy"}}
+<-- {"jsonrpc":"2.0","method":"nftest_subscription","params":{"subscription":"0x4","result":"hi lily"}}
+
 --> {"jsonrpc":"2.0","id":2,"method":"nftest_echo","params":[11]}
 <-- {"jsonrpc":"2.0","id":2,"result":11}


### PR DESCRIPTION
For epochs pubsub, we need to use variadic arguments to receipt epoch subscription type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/go-conflux-sdk/93)
<!-- Reviewable:end -->
