### PR TITLE
refactor: fix NewNetworkType and NetworkTypeTypeMainnetID naming typos

### DIFF
--- a/types/cfxaddress/address.go
+++ b/types/cfxaddress/address.go
@@ -98,7 +98,7 @@ func NewFromBase32(base32Str string) (cfxAddress Address, err error) {
 		return cfxAddress, errors.Errorf("base32 string %v is invalid format", base32Str)
 	}
 
-	cfxAddress.networkType, err = NewNetowrkType(parts[0])
+	cfxAddress.networkType, err = NewNetworkType(parts[0])
 	if err != nil {
 		return cfxAddress, errors.Wrapf(err, "failed to get network type of %v", parts[0])
 	}

--- a/types/cfxaddress/network_type.go
+++ b/types/cfxaddress/network_type.go
@@ -28,12 +28,14 @@ const (
 	NetworkTypeMainnetPrefix NetworkType = "cfx"
 	NetworkTypeTestNetPrefix NetworkType = "cfxtest"
 
-	NetowrkTypeMainnetID uint32 = 1029
+	// Deprecated: use NetworkTypeMainnetID instead, this constant will be removed in the future
+	NetowrkTypeMainnetID uint32 = NetworkTypeMainnetID
+	NetworkTypeMainnetID uint32 = 1029
 	NetworkTypeTestnetID uint32 = 1
 )
 
-// NewNetowrkType creates network type by string
-func NewNetowrkType(netType string) (NetworkType, error) {
+// NewNetworkType creates network type by string
+func NewNetworkType(netType string) (NetworkType, error) {
 	if netType == NetworkTypeMainnetPrefix.String() || netType == NetworkTypeTestNetPrefix.String() {
 		return NetworkType(netType), nil
 	}
@@ -44,11 +46,17 @@ func NewNetowrkType(netType string) (NetworkType, error) {
 	return NetworkType(netType), nil
 }
 
+// NewNetowrkType creates network type by string
+// Deprecated: use NewNetworkType instead, this function will be removed in the future
+func NewNetowrkType(netType string) (NetworkType, error) {
+	return NewNetworkType(netType)
+}
+
 // NewNetworkTypeByID creates network type by network ID
 func NewNetworkTypeByID(networkID uint32) NetworkType {
 	var nt NetworkType
 	switch networkID {
-	case NetowrkTypeMainnetID:
+	case NetworkTypeMainnetID:
 		nt = NetworkTypeMainnetPrefix
 	case NetworkTypeTestnetID:
 		nt = NetworkTypeTestNetPrefix
@@ -62,7 +70,7 @@ func NewNetworkTypeByID(networkID uint32) NetworkType {
 func (n NetworkType) ToNetworkID() (uint32, error) {
 	switch n {
 	case NetworkTypeMainnetPrefix:
-		return NetowrkTypeMainnetID, nil
+		return NetworkTypeMainnetID, nil
 	case NetworkTypeTestNetPrefix:
 		return NetworkTypeTestnetID, nil
 	default:


### PR DESCRIPTION
Previous values marked as deprecated for backward compatibility

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/go-conflux-sdk/227)
<!-- Reviewable:end -->
