### PR TITLE
cfx_feehistory input blockCount is supported by hex or decimal uint64

### DIFF
--- a/client.go
+++ b/client.go
@@ -734,7 +734,7 @@ func (client *Client) GetPoSRewardByEpoch(epoch types.Epoch) (reward *postypes.E
 }
 
 // GetFeeHistory returns transaction base fee per gas and effective priority fee per gas for the requested/supported epoch range.
-func (client *Client) GetFeeHistory(blockCount hexutil.Uint64, lastEpoch types.Epoch, rewardPercentiles []float64) (feeHistory *types.FeeHistory, err error) {
+func (client *Client) GetFeeHistory(blockCount types.HexOrDecimalUint64, lastEpoch types.Epoch, rewardPercentiles []float64) (feeHistory *types.FeeHistory, err error) {
 	err = client.wrappedCallRPC(&feeHistory, "cfx_feeHistory", blockCount, lastEpoch, rewardPercentiles)
 	return
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Conflux-Chain/go-conflux-sdk
 
-go 1.18
+go 1.22
 
 require (
 	github.com/ethereum/go-ethereum v1.10.15

--- a/interface.go
+++ b/interface.go
@@ -115,7 +115,7 @@ type ClientOperator interface {
 	GetPoSEconomics(epoch ...*types.Epoch) (posEconomics types.PoSEconomics, err error)
 	GetOpenedMethodGroups() (openedGroups []string, err error)
 	GetPoSRewardByEpoch(epoch types.Epoch) (reward *postypes.EpochReward, err error)
-	GetFeeHistory(blockCount hexutil.Uint64, lastEpoch types.Epoch, rewardPercentiles []float64) (feeHistory *types.FeeHistory, err error)
+	GetFeeHistory(blockCount types.HexOrDecimalUint64, lastEpoch types.Epoch, rewardPercentiles []float64) (feeHistory *types.FeeHistory, err error)
 	GetMaxPriorityFeePerGas() (maxPriorityFeePerGas *hexutil.Big, err error)
 	GetFeeBurnt(epoch ...*types.Epoch) (info *hexutil.Big, err error)
 

--- a/types/types.go
+++ b/types/types.go
@@ -81,3 +81,27 @@ func NewUint(x uint) *hexutil.Uint {
 func NewBytes(input []byte) hexutil.Bytes {
 	return hexutil.Bytes(input)
 }
+
+type HexOrDecimalUint64 uint64
+
+func (u HexOrDecimalUint64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(uint64(u))
+}
+
+func (u *HexOrDecimalUint64) UnmarshalJSON(data []byte) error {
+	if data[0] == byte('"') && data[len(data)-1] == byte('"') {
+		var val hexutil.Uint64
+		if err := json.Unmarshal(data, &val); err != nil {
+			return err
+		}
+		*u = HexOrDecimalUint64(val)
+		return nil
+	}
+
+	var val uint64
+	if err := json.Unmarshal(data, &val); err != nil {
+		return err
+	}
+	*u = HexOrDecimalUint64(val)
+	return nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -85,7 +85,7 @@ func NewBytes(input []byte) hexutil.Bytes {
 type HexOrDecimalUint64 uint64
 
 func (u HexOrDecimalUint64) MarshalJSON() ([]byte, error) {
-	return json.Marshal(uint64(u))
+	return json.Marshal(hexutil.Uint64(u))
 }
 
 func (u *HexOrDecimalUint64) UnmarshalJSON(data []byte) error {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -61,7 +61,7 @@ func TestHexOrDecimalUint64(t *testing.T) {
 		u := HexOrDecimalUint64(10)
 		b, err := json.Marshal(u)
 		assert.NoError(t, err)
-		assert.Equal(t, string(b), "10")
+		assert.Equal(t, string(b), "\"0xa\"")
 	})
 
 	t.Run("Json Unmarshal", func(t *testing.T) {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -3,6 +3,8 @@ package types
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnmarshalJsonHash(t *testing.T) {
@@ -52,4 +54,28 @@ func TestUnmarshalJsonHash(t *testing.T) {
 		}
 
 	}
+}
+
+func TestHexOrDecimalUint64(t *testing.T) {
+	t.Run("Json Marshal", func(t *testing.T) {
+		u := HexOrDecimalUint64(10)
+		b, err := json.Marshal(u)
+		assert.NoError(t, err)
+		assert.Equal(t, string(b), "10")
+	})
+
+	t.Run("Json Unmarshal", func(t *testing.T) {
+		table := []string{
+			"10",
+			"\"0xa\"",
+		}
+
+		for _, b := range table {
+			var u HexOrDecimalUint64
+			err := json.Unmarshal([]byte(b), &u)
+			assert.NoError(t, err)
+
+			assert.Equal(t, HexOrDecimalUint64(10), u)
+		}
+	})
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/go-conflux-sdk/236)
<!-- Reviewable:end -->
