### PR TITLE
fix: fix the problem of struct field has repeats json tag

### DIFF
--- a/types/pos/transaction_payload.go
+++ b/types/pos/transaction_payload.go
@@ -46,8 +46,8 @@ func (b *TransactionPayload) UnmarshalJSON(data []byte) error {
 }
 
 type ElectionPayload struct {
-	PublicKey    string         `json:"publicKey"`
-	VrfPublicKey string         `json:"vrfPublicKey"`
+	PublicKey    string         `json:"electionPublicKey"`
+	VrfPublicKey string         `json:"electionVrfPublicKey"`
 	TargetTerm   hexutil.Uint64 `json:"targetTerm"`
 	VrfProof     string         `json:"vrfProof"`
 }
@@ -58,8 +58,8 @@ type RetirePayload struct {
 }
 
 type RegisterPayload struct {
-	PublicKey    string `json:"publicKey"`
-	VrfPublicKey string `json:"vrfPublicKey"`
+	PublicKey    string `json:"registerPublicKey"`
+	VrfPublicKey string `json:"registerVrfPublicKey"`
 }
 
 type UpdateVotingPowerPayload struct {


### PR DESCRIPTION
go vet ./... warning:

```shell
# [github.com/Conflux-Chain/go-conflux-sdk/types/pos]
types/pos/transaction_payload.go:16:2: struct field PublicKey repeats json tag "publicKey" also at transaction_payload.go:49
types/pos/transaction_payload.go:16:2: struct field VrfPublicKey repeats json tag "vrfPublicKey" also at transaction_payload.go:50
types/pos/transaction_payload.go:19:2: struct field VrfPublicKey repeats json tag "vrfPublicKey" also at transaction_payload.go:50
```


This pr solve this problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/go-conflux-sdk/245)
<!-- Reviewable:end -->
